### PR TITLE
chore(ci): bootstrap frontend CI from monorepo (aeb2a20)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run lint
-        run: pnpm lint || true
+        run: pnpm lint
 
   build:
     name: frontend:build


### PR DESCRIPTION
This PR bootstraps/updates the frontend CI workflow in the target repo from the monorepo.